### PR TITLE
chromebook-setup: Add deploy kernel only command

### DIFF
--- a/chromebook-setup.sh
+++ b/chromebook-setup.sh
@@ -616,6 +616,15 @@ cmd_deploy_kernel()
     cmd_eject_storage
 }
 
+cmd_deploy_kernel_only()
+{
+    cmd_mount_rootfs
+    cmd_build_kernel
+    cmd_build_vboot
+    cmd_deploy_vboot
+    cmd_eject_storage
+}
+
 # These commands are required
 ensure_command bc bc
 ensure_command curl curl


### PR DESCRIPTION
Sometimes we just want to update the kernel fit image,
e.g. change the device tree or the kernel boot comand.
In this case we don't need to copy again the whole kernel modules
which takes a lot of time. Option deploy_kernel_only just
builds a fit image and writes it to the storage medium.

Signed-off-by: Matthias Brugger <mbrugger@suse.com>