### PR TITLE
Tool for preparing Fedora Image on the chromebook

### DIFF
--- a/chromebook-config.sh
+++ b/chromebook-config.sh
@@ -14,6 +14,9 @@ ARM64_TOOLCHAIN_URL="https://armkeil.blob.core.windows.net/developer/Files/downl
 DEBIAN_SUITE="sid"
 ROOTFS_BASE_URL="https://people.collabora.com/~eballetbo/debian/images/"
 
+# Fedora rootfs images
+GETFEDORA="https://download.fedoraproject.org/pub/fedora/linux/releases/36/Workstation/aarch64/images/Fedora-Workstation-36-1.5.aarch64.raw.xz"
+
 KERNEL_URL="git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git"
 
 # Current Working Directory


### PR DESCRIPTION
This tool reuses some of the functions for creating ChromeOS bootable partitions, 
mounts the ROOTFS partition, prepares the Fedora rootfs, generates a FIT image using the kernel https://download.copr.fedorainfracloud.org/results/eballetbo/fedora/fedora-35-aarch64/03507242-kernel/ for the kernel partition, signs the kernel and creates a bootable media for the chromebook.

Signed-off-by: Dorinda Bassey <dbassey@redhat.com>