### PR TITLE
Add kparams and initrd options

### DIFF
--- a/chromebook-setup.sh
+++ b/chromebook-setup.sh
@@ -78,6 +78,9 @@ Options:
   --architecture=ARCH
     Chromebook architecture, needs to be one of the following: arm | arm64 | x86_64
 
+  --kparams=PARAMETERS
+    Additional parameters to be added to the kernel command line.
+
 Available commands:
 
   help
@@ -173,7 +176,7 @@ or to do the same to use NFS for the root filesystem:
     exit $arg_ret
 }
 
-opts=$(getopt -o "h,s:" -l "help,image:,distro:,kernel:,storage:,architecture:" -- "$@")
+opts=$(getopt -o "h,s:" -l "help,image:,distro:,kernel:,storage:,architecture:,kparams:" -- "$@")
 eval set -- "$opts"
 
 while true; do
@@ -199,6 +202,10 @@ while true; do
             ;;
         --architecture)
             ARCH="$2"
+            shift 2
+            ;;
+        --kparams)
+            EXTRA_KPARAMS="$2"
             shift 2
             ;;
         --)
@@ -618,7 +625,7 @@ cmd_build_vboot()
     local arch
     local bootloader
     local vmlinuz
-    local extra_kparams
+    local extra_kparams=$EXTRA_KPARAMS
 
     echo "Sign the kernels to boot with Chrome OS devices..."
 
@@ -633,7 +640,7 @@ cmd_build_vboot()
             [ -f ./bootstub/bootstub.efi ] || cmd_build_bootstub
             bootloader="./bootstub/bootstub.efi"
             vmlinuz="$CB_KERNEL_PATH/arch/x86/boot/bzImage"
-            extra_kparams="tpm_tis.force=1 tpm_tis.interrupts=0"
+            extra_kparams="${extra_kparams} tpm_tis.force=1 tpm_tis.interrupts=0"
             ;;
         *)
             echo "Unsupported vboot architecture"

--- a/chromebook-setup.sh
+++ b/chromebook-setup.sh
@@ -81,6 +81,9 @@ Options:
   --kparams=PARAMETERS
     Additional parameters to be added to the kernel command line.
 
+  --initrd=INITRD
+    Initrd to be added to the FIT image.
+
 Available commands:
 
   help
@@ -176,7 +179,7 @@ or to do the same to use NFS for the root filesystem:
     exit $arg_ret
 }
 
-opts=$(getopt -o "h,s:" -l "help,image:,distro:,kernel:,storage:,architecture:,kparams:" -- "$@")
+opts=$(getopt -o "h,s:" -l "help,image:,distro:,kernel:,storage:,architecture:,kparams:,initrd:" -- "$@")
 eval set -- "$opts"
 
 while true; do
@@ -206,6 +209,10 @@ while true; do
             ;;
         --kparams)
             EXTRA_KPARAMS="$2"
+            shift 2
+            ;;
+        --initrd)
+            INITRD="$2"
             shift 2
             ;;
         --)
@@ -395,8 +402,12 @@ create_fit_image()
             fi
          fi
 
+	 local initrd_option=""
+         if [ -n "$INITRD" ]; then
+            initrd_option="-i $INITRD"
+         fi
          mkimage -D "-I dts -O dtb -p 2048" -f auto -A ${ARCH} -O linux -T kernel -C $compression -a 0 \
-                 -d arch/${ARCH}/boot/$kernel $dtbs \
+                 -d arch/${ARCH}/boot/$kernel ${initrd_option} $dtbs \
                  kernel.itb
     else
 	echo "TODO: create x86_64 FIT image, now using a raw image"

--- a/chromebook-setup.sh
+++ b/chromebook-setup.sh
@@ -143,8 +143,14 @@ Available commands:
   build_kernel
     Compile the Linux kernel modules.
 
+  deploy_kernel
+   Install the Linux kernel as a vboot image and its modules on the rootfs.
+
+  deploy_kernel_only
+   Install only the Linux kernel as a vboot image but no its modules.
+
   deploy_kernel_modules
-    Install the Linux kernel modules on the rootfs.
+    Install only the Linux kernel modules on the rootfs but no the image.
 
   build_bootstub
     Build the ChromeOS bootstub.efi.


### PR DESCRIPTION
To allow setting additional kernel command line parameters and specifying an initrd to be included in the FIT images.