### PR TITLE
Extend Fedora to support kernel updates on chromebooks

### DIFF
--- a/chromebook-setup.sh
+++ b/chromebook-setup.sh
@@ -742,6 +742,11 @@ cmd_setup_fedora_rootfs()
     -e '/home/s/btrfs/ext4/' \
     -e 's/subvol=home,compress=zstd:1/defaults/' ./tmpdir/root/etc/fstab
 
+    # Insert the Kernel update script
+    echo "Inserting Kernel Update script"
+    sudo chmod 777 scripts/96-chromebook.install
+    sudo cp scripts/96-chromebook.install ./tmpdir/root/usr/lib/kernel/install.d/
+
     # Copy the ROOTFS to media
     echo "copying ROOTFS to partition"
     sudo cp -ar "./tmpdir/root/"* "$ROOTFS_DIR"

--- a/scripts/96-chromebook.install
+++ b/scripts/96-chromebook.install
@@ -1,0 +1,84 @@
+#!/usr/bin/bash
+
+COMMAND="$1"
+KERNEL_VERSION="$2"
+BOOT_DIR_ABS="$3"
+KERNEL_IMAGE="$4"
+
+if [[ -d "$BOOT_DIR_ABS" ]]; then
+    INITRD="initrd"
+else
+    BOOT_DIR_ABS="/boot"
+    INITRD="initramfs-${KERNEL_VERSION}.img"
+fi
+
+KERNEL_VBOOT="kernel.vboot"
+KERNEL_ITB="kernel.itb"
+
+ensure_command() {
+    # ensure_command foo foo-package
+    which "$1" 2>/dev/null 1>/dev/null ||
+    sudo which "$1" 2>/dev/null 1>/dev/null || (
+        echo "Install required command $1 from package $2, e.g. sudo dnf install $2"
+        exit 1
+    )
+}
+
+ensure_command lz4 lz4
+ensure_command mkimage uboot-tools
+ensure_command vbutil_kernel vboot-utils
+
+case "$COMMAND" in
+    add)
+        if [[ -f "$BOOT_DIR_ABS/$INITRD" ]]; then
+            kernel="${KERNEL_IMAGE##*/}-${KERNEL_VERSION}.lz4"
+            # Compression method being used by coreboot
+            compression="lz4"
+            rm -f "$BOOT_DIR_ABS/${KERNEL_IMAGE##*/}-${KERNEL_VERSION}.lz4" || true
+            lz4 "$BOOT_DIR_ABS/${KERNEL_IMAGE##*/}-${KERNEL_VERSION}" "$BOOT_DIR_ABS/${KERNEL_IMAGE##*/}-${KERNEL_VERSION}.lz4"
+
+            #Fedora kernel generates these device tree 
+            #FIXME: other existing dtb in /boot/dtb/* doesn't work with the FIT image
+            dtbs="-b /boot/dtb/qcom/sc7180-trogdor-coachz-r3.dtb \
+		          -b /boot/dtb/qcom/sc7180-trogdor-lazor-r3-kb.dtb \
+                  -b /boot/dtb/rockchip/rk3399-gru-kevin.dtb\
+                  -b /boot/dtb/rockchip/rk3399-gru-scarlet-inx.dtb \
+		          "
+            mkimage -D "-I dts -O dtb -p 2048" -i "$BOOT_DIR_ABS/$INITRD" \
+                    -f auto -A arm64 -O linux -T kernel -C $compression -a 0 \
+                    -d /boot/$kernel $dtbs \
+                    $BOOT_DIR_ABS/$KERNEL_ITB
+
+            if [[ -f /etc/kernel/cmdline ]]; then
+                read -r -d '' -a BOOT_OPTIONS < /etc/kernel/cmdline
+            elif [[ -f /usr/lib/kernel/cmdline ]]; then
+                read -r -d '' -a BOOT_OPTIONS < /usr/lib/kernel/cmdline
+            else
+                declare -a BOOT_OPTIONS
+                read -r -d '' BOOT_OPTIONS < /proc/cmdline
+            fi
+            echo "$BOOT_OPTIONS" > boot_params
+            vbutil_kernel --pack $BOOT_DIR_ABS/$KERNEL_VBOOT \
+                            --keyblock /usr/share/vboot/devkeys/kernel.keyblock \
+                            --signprivate /usr/share/vboot/devkeys/kernel_data_key.vbprivk \
+                            --version 1 --config boot_params \
+                            --bootloader boot_params \
+                            --vmlinuz $BOOT_DIR_ABS/$KERNEL_ITB \
+                            --arch arm
+            for i in /dev/disk/by-id/*; do
+                dev=$(cgpt find -t kernel)
+                for device in $dev; do
+                    break
+                done
+            break
+            done
+            dd if=$BOOT_DIR_ABS/$KERNEL_VBOOT of=$device bs=4M status=progress
+        fi
+        ;;
+    remove)
+        rm -f -- "$BOOT_DIR_ABS/$INITRD" "$BOOT_DIR_ABS/$KERNEL_VBOOT" "$BOOT_DIR_ABS/$KERNEL_ITB" "boot_params"
+        ;;
+    *)
+        exit 0
+esac
+exit 0


### PR DESCRIPTION
Added a kernel-install script that creates an intramfs and FIT Image (including the ramdisk)
then the script flashes the kernel to the right partition in order to support kernel updates on the chromebook

Signed-off-by: Dorinda Bassey <dbassey@redhat.com>