### PR TITLE
Referring to image with absolute path fails when using deploy_fedora

### DIFF
--- a/chromebook-setup.sh
+++ b/chromebook-setup.sh
@@ -721,8 +721,8 @@ cmd_setup_fedora_rootfs()
     local image
     local btrfs
 
-    image=$IMAGE
-    loopdev="$(sudo losetup --show -fP $image)"
+    image=$(basename $IMAGE)
+    loopdev="$(sudo losetup --show -fP $IMAGE)"
     btrfs="${image/raw/btrfs}"
     sudo dd if="${loopdev}p3" of="/var/tmp/$btrfs" conv=fsync status=progress
     sudo losetup -D


### PR DESCRIPTION
I was calling the script like so:

./chromebook-setup.sh deploy_fedora --architecture=arm64 \
  --image=/home/user/Downloads/Fedora-Workstation-36-1.5.aarch64.raw \
  --storage=/dev/sda

which fails as --image expects the image file to be in the same
directory as chromebook-setup.sh and to be called with simply a
filename. This uses just the filename where appropriate.