### PR TITLE
Chromebook install script fixes and improvements

### DIFF
--- a/scripts/96-chromebook.install
+++ b/scripts/96-chromebook.install
@@ -25,6 +25,7 @@ case "$COMMAND" in
             exit 77;
         fi
 
+        cp -aT "${KERNEL_IMAGE}" "${BOOT_DIR_ABS}/${kernel}"
         rm -f "$BOOT_DIR_ABS/${kernel}.${compression}" || true
         "${compression}" "$BOOT_DIR_ABS/${kernel}" "$BOOT_DIR_ABS/${kernel}.${compression}" 2> /dev/null
 

--- a/scripts/96-chromebook.install
+++ b/scripts/96-chromebook.install
@@ -17,6 +17,7 @@ KERNEL_ITB="kernel.itb"
 # Compression method being used by coreboot
 compression="lz4"
 kernel="${KERNEL_IMAGE##*/}-${KERNEL_VERSION}"
+tmpdir="$(mktemp -d /tmp/chromebook-install.XXXX)"
 
 case "$COMMAND" in
     add)
@@ -26,8 +27,8 @@ case "$COMMAND" in
         fi
 
         cp -aT "${KERNEL_IMAGE}" "${BOOT_DIR_ABS}/${kernel}"
-        rm -f "$BOOT_DIR_ABS/${kernel}.${compression}" || true
-        "${compression}" "$BOOT_DIR_ABS/${kernel}" "$BOOT_DIR_ABS/${kernel}.${compression}" 2> /dev/null
+        cp -aT "${KERNEL_IMAGE}" "${tmpdir}/${kernel}"
+        ${compression} "${tmpdir}/${kernel}" "${tmpdir}/${kernel}.${compression}" 2> /dev/null
 
         #Fedora kernel generates these device tree
         #FIXME: other existing dtb in /boot/dtb/* doesn't work with the FIT image
@@ -36,10 +37,10 @@ case "$COMMAND" in
               -b /boot/dtb/rockchip/rk3399-gru-kevin.dtb\
               -b /boot/dtb/rockchip/rk3399-gru-scarlet-inx.dtb"
 
-        mkimage -D "-I dts -O dtb -p 2048" -i "$BOOT_DIR_ABS/$INITRD" \
-                -f auto -A arm64 -O linux -T kernel -C $compression -a 0 \
-                -d /boot/"${kernel}.${compression}" $dtbs \
-                $BOOT_DIR_ABS/$KERNEL_ITB > /dev/null
+        mkimage -D "-I dts -O dtb -p 2048" -i "${BOOT_DIR_ABS}/${INITRD}" \
+                -f auto -A arm64 -O linux -T kernel -C "${compression}" -a 0 \
+                -d "${tmpdir}/${kernel}.${compression}" ${dtbs} \
+                "${tmpdir}/${KERNEL_ITB}" > /dev/null
 
         if [[ -f /etc/kernel/cmdline ]]; then
             read -r -d '' -a BOOT_OPTIONS < /etc/kernel/cmdline
@@ -51,15 +52,16 @@ case "$COMMAND" in
             read -r -d '' BOOT_OPTIONS < /proc/cmdline
         fi
 
-        cmdline=boot_params
+        cmdline="${tmpdir}"/boot_params
 
         echo "${BOOT_OPTIONS}" > "${cmdline}"
-        vbutil_kernel --pack $BOOT_DIR_ABS/$KERNEL_VBOOT \
+
+        vbutil_kernel --pack "${tmpdir}/${KERNEL_VBOOT}" \
                       --keyblock /usr/share/vboot/devkeys/kernel.keyblock \
                       --signprivate /usr/share/vboot/devkeys/kernel_data_key.vbprivk \
                       --version 1 --config "${cmdline}" \
                       --bootloader "${cmdline}" \
-                      --vmlinuz $BOOT_DIR_ABS/$KERNEL_ITB \
+                      --vmlinuz "${tmpdir}/${KERNEL_ITB}" \
                       --arch arm > /dev/null
         for i in /dev/disk/by-id/*; do
             dev=$(cgpt find -t kernel)
@@ -68,10 +70,11 @@ case "$COMMAND" in
             done
             break
         done
-        dd if=$BOOT_DIR_ABS/$KERNEL_VBOOT of=$device bs=4M status=none
+        dd if="${tmpdir}/${KERNEL_VBOOT}" of="${dev}" bs=4M status=none
+        rm -rf "${tmpdir}"
         ;;
     remove)
-        rm -f -- "$BOOT_DIR_ABS/$INITRD" "$BOOT_DIR_ABS/$KERNEL_VBOOT" "$BOOT_DIR_ABS/$KERNEL_ITB" "boot_params"
+        rm -f "${BOOT_DIR_ABS}/${kernel}" "${BOOT_DIR_ABS}/${INITRD}"
         ;;
     *)
         exit 0

--- a/scripts/96-chromebook.install
+++ b/scripts/96-chromebook.install
@@ -26,7 +26,7 @@ case "$COMMAND" in
         fi
 
         rm -f "$BOOT_DIR_ABS/${kernel}.${compression}" || true
-        "${compression}" "$BOOT_DIR_ABS/${kernel}" "$BOOT_DIR_ABS/${kernel}.${compression}"
+        "${compression}" "$BOOT_DIR_ABS/${kernel}" "$BOOT_DIR_ABS/${kernel}.${compression}" 2> /dev/null
 
         #Fedora kernel generates these device tree
         #FIXME: other existing dtb in /boot/dtb/* doesn't work with the FIT image
@@ -38,7 +38,7 @@ case "$COMMAND" in
         mkimage -D "-I dts -O dtb -p 2048" -i "$BOOT_DIR_ABS/$INITRD" \
                 -f auto -A arm64 -O linux -T kernel -C $compression -a 0 \
                 -d /boot/"${kernel}.${compression}" $dtbs \
-                $BOOT_DIR_ABS/$KERNEL_ITB
+                $BOOT_DIR_ABS/$KERNEL_ITB > /dev/null
 
         if [[ -f /etc/kernel/cmdline ]]; then
             read -r -d '' -a BOOT_OPTIONS < /etc/kernel/cmdline
@@ -56,7 +56,7 @@ case "$COMMAND" in
                       --version 1 --config boot_params \
                       --bootloader boot_params \
                       --vmlinuz $BOOT_DIR_ABS/$KERNEL_ITB \
-                      --arch arm
+                      --arch arm > /dev/null
         for i in /dev/disk/by-id/*; do
             dev=$(cgpt find -t kernel)
             for device in $dev; do
@@ -64,7 +64,7 @@ case "$COMMAND" in
             done
             break
         done
-        dd if=$BOOT_DIR_ABS/$KERNEL_VBOOT of=$device bs=4M status=progress
+        dd if=$BOOT_DIR_ABS/$KERNEL_VBOOT of=$device bs=4M status=none
         ;;
     remove)
         rm -f -- "$BOOT_DIR_ABS/$INITRD" "$BOOT_DIR_ABS/$KERNEL_VBOOT" "$BOOT_DIR_ABS/$KERNEL_ITB" "boot_params"

--- a/scripts/96-chromebook.install
+++ b/scripts/96-chromebook.install
@@ -27,7 +27,8 @@ case "$COMMAND" in
         fi
 
         cp -aT "${KERNEL_IMAGE}" "${BOOT_DIR_ABS}/${kernel}"
-        cp -aT "${KERNEL_IMAGE}" "${tmpdir}/${kernel}"
+        cp -aT "${KERNEL_IMAGE}" "${tmpdir}/${kernel}.gz"
+        gunzip "${tmpdir}/${kernel}.gz"
         ${compression} "${tmpdir}/${kernel}" "${tmpdir}/${kernel}.${compression}" 2> /dev/null
 
         #Fedora kernel generates these device tree

--- a/scripts/96-chromebook.install
+++ b/scripts/96-chromebook.install
@@ -17,51 +17,54 @@ KERNEL_ITB="kernel.itb"
 
 case "$COMMAND" in
     add)
-        if [[ -f "$BOOT_DIR_ABS/$INITRD" ]]; then
-            kernel="${KERNEL_IMAGE##*/}-${KERNEL_VERSION}.lz4"
-            # Compression method being used by coreboot
-            compression="lz4"
-            rm -f "$BOOT_DIR_ABS/${KERNEL_IMAGE##*/}-${KERNEL_VERSION}.lz4" || true
-            lz4 "$BOOT_DIR_ABS/${KERNEL_IMAGE##*/}-${KERNEL_VERSION}" "$BOOT_DIR_ABS/${KERNEL_IMAGE##*/}-${KERNEL_VERSION}.lz4"
-
-            #Fedora kernel generates these device tree 
-            #FIXME: other existing dtb in /boot/dtb/* doesn't work with the FIT image
-            dtbs="-b /boot/dtb/qcom/sc7180-trogdor-coachz-r3.dtb \
-		          -b /boot/dtb/qcom/sc7180-trogdor-lazor-r3-kb.dtb \
-                  -b /boot/dtb/rockchip/rk3399-gru-kevin.dtb\
-                  -b /boot/dtb/rockchip/rk3399-gru-scarlet-inx.dtb \
-		          "
-            mkimage -D "-I dts -O dtb -p 2048" -i "$BOOT_DIR_ABS/$INITRD" \
-                    -f auto -A arm64 -O linux -T kernel -C $compression -a 0 \
-                    -d /boot/$kernel $dtbs \
-                    $BOOT_DIR_ABS/$KERNEL_ITB
-
-            if [[ -f /etc/kernel/cmdline ]]; then
-                read -r -d '' -a BOOT_OPTIONS < /etc/kernel/cmdline
-
-            elif [[ -f /usr/lib/kernel/cmdline ]]; then
-                read -r -d '' -a BOOT_OPTIONS < /usr/lib/kernel/cmdline
-            else
-                declare -a BOOT_OPTIONS
-                read -r -d '' BOOT_OPTIONS < /proc/cmdline
-            fi
-            echo "$BOOT_OPTIONS" > boot_params
-            vbutil_kernel --pack $BOOT_DIR_ABS/$KERNEL_VBOOT \
-                            --keyblock /usr/share/vboot/devkeys/kernel.keyblock \
-                            --signprivate /usr/share/vboot/devkeys/kernel_data_key.vbprivk \
-                            --version 1 --config boot_params \
-                            --bootloader boot_params \
-                            --vmlinuz $BOOT_DIR_ABS/$KERNEL_ITB \
-                            --arch arm
-            for i in /dev/disk/by-id/*; do
-                dev=$(cgpt find -t kernel)
-                for device in $dev; do
-                    break
-                done
-            break
-            done
-            dd if=$BOOT_DIR_ABS/$KERNEL_VBOOT of=$device bs=4M status=progress
+        # Fail early if an initrd was not created for this kernel
+        if [[ ! -f "$BOOT_DIR_ABS/$INITRD" ]]; then
+            exit 77;
         fi
+
+        kernel="${KERNEL_IMAGE##*/}-${KERNEL_VERSION}.lz4"
+        # Compression method being used by coreboot
+        compression="lz4"
+        rm -f "$BOOT_DIR_ABS/${KERNEL_IMAGE##*/}-${KERNEL_VERSION}.lz4" || true
+        lz4 "$BOOT_DIR_ABS/${KERNEL_IMAGE##*/}-${KERNEL_VERSION}" "$BOOT_DIR_ABS/${KERNEL_IMAGE##*/}-${KERNEL_VERSION}.lz4"
+
+        #Fedora kernel generates these device tree
+        #FIXME: other existing dtb in /boot/dtb/* doesn't work with the FIT image
+        dtbs="-b /boot/dtb/qcom/sc7180-trogdor-coachz-r3.dtb \
+              -b /boot/dtb/qcom/sc7180-trogdor-lazor-r3-kb.dtb \
+              -b /boot/dtb/rockchip/rk3399-gru-kevin.dtb\
+              -b /boot/dtb/rockchip/rk3399-gru-scarlet-inx.dtb"
+
+        mkimage -D "-I dts -O dtb -p 2048" -i "$BOOT_DIR_ABS/$INITRD" \
+                -f auto -A arm64 -O linux -T kernel -C $compression -a 0 \
+                -d /boot/$kernel $dtbs \
+                $BOOT_DIR_ABS/$KERNEL_ITB
+
+        if [[ -f /etc/kernel/cmdline ]]; then
+            read -r -d '' -a BOOT_OPTIONS < /etc/kernel/cmdline
+
+        elif [[ -f /usr/lib/kernel/cmdline ]]; then
+            read -r -d '' -a BOOT_OPTIONS < /usr/lib/kernel/cmdline
+        else
+            declare -a BOOT_OPTIONS
+            read -r -d '' BOOT_OPTIONS < /proc/cmdline
+        fi
+        echo "$BOOT_OPTIONS" > boot_params
+        vbutil_kernel --pack $BOOT_DIR_ABS/$KERNEL_VBOOT \
+                      --keyblock /usr/share/vboot/devkeys/kernel.keyblock \
+                      --signprivate /usr/share/vboot/devkeys/kernel_data_key.vbprivk \
+                      --version 1 --config boot_params \
+                      --bootloader boot_params \
+                      --vmlinuz $BOOT_DIR_ABS/$KERNEL_ITB \
+                      --arch arm
+        for i in /dev/disk/by-id/*; do
+            dev=$(cgpt find -t kernel)
+            for device in $dev; do
+                break
+            done
+            break
+        done
+        dd if=$BOOT_DIR_ABS/$KERNEL_VBOOT of=$device bs=4M status=progress
         ;;
     remove)
         rm -f -- "$BOOT_DIR_ABS/$INITRD" "$BOOT_DIR_ABS/$KERNEL_VBOOT" "$BOOT_DIR_ABS/$KERNEL_ITB" "boot_params"

--- a/scripts/96-chromebook.install
+++ b/scripts/96-chromebook.install
@@ -64,14 +64,19 @@ case "$COMMAND" in
                       --bootloader "${cmdline}" \
                       --vmlinuz "${tmpdir}/${KERNEL_ITB}" \
                       --arch arm > /dev/null
-        for i in /dev/disk/by-id/*; do
-            dev=$(cgpt find -t kernel)
-            for device in $dev; do
-                break
-            done
-            break
+
+        # Store the FIT image in a partition of type kernel, that is present in
+        # the storage device of the partition that is used to mount the rootfs.
+        major="$(mountpoint -d / | cut -d ':' -f1)"
+        sysfs="$(find /sys/dev -name ${major}:0)"
+        devnode="$(grep DEVNAME ${sysfs}/uevent | cut -d '=' -f2)"
+
+        partitions="$(cgpt find -t kernel)"
+        for part in ${partitions}; do
+            if [[ "${part##*/}" == "${devnode}"* ]]; then
+                dd if="${tmpdir}/${KERNEL_VBOOT}" of="${part}" bs=4M status=none
+            fi
         done
-        dd if="${tmpdir}/${KERNEL_VBOOT}" of="${dev}" bs=4M status=none
         rm -rf "${tmpdir}"
         ;;
     remove)

--- a/scripts/96-chromebook.install
+++ b/scripts/96-chromebook.install
@@ -15,19 +15,6 @@ fi
 KERNEL_VBOOT="kernel.vboot"
 KERNEL_ITB="kernel.itb"
 
-ensure_command() {
-    # ensure_command foo foo-package
-    which "$1" 2>/dev/null 1>/dev/null ||
-    sudo which "$1" 2>/dev/null 1>/dev/null || (
-        echo "Install required command $1 from package $2, e.g. sudo dnf install $2"
-        exit 1
-    )
-}
-
-ensure_command lz4 lz4
-ensure_command mkimage uboot-tools
-ensure_command vbutil_kernel vboot-utils
-
 case "$COMMAND" in
     add)
         if [[ -f "$BOOT_DIR_ABS/$INITRD" ]]; then
@@ -51,6 +38,7 @@ case "$COMMAND" in
 
             if [[ -f /etc/kernel/cmdline ]]; then
                 read -r -d '' -a BOOT_OPTIONS < /etc/kernel/cmdline
+
             elif [[ -f /usr/lib/kernel/cmdline ]]; then
                 read -r -d '' -a BOOT_OPTIONS < /usr/lib/kernel/cmdline
             else

--- a/scripts/96-chromebook.install
+++ b/scripts/96-chromebook.install
@@ -49,12 +49,15 @@ case "$COMMAND" in
             declare -a BOOT_OPTIONS
             read -r -d '' BOOT_OPTIONS < /proc/cmdline
         fi
-        echo "$BOOT_OPTIONS" > boot_params
+
+        cmdline=boot_params
+
+        echo "${BOOT_OPTIONS}" > "${cmdline}"
         vbutil_kernel --pack $BOOT_DIR_ABS/$KERNEL_VBOOT \
                       --keyblock /usr/share/vboot/devkeys/kernel.keyblock \
                       --signprivate /usr/share/vboot/devkeys/kernel_data_key.vbprivk \
-                      --version 1 --config boot_params \
-                      --bootloader boot_params \
+                      --version 1 --config "${cmdline}" \
+                      --bootloader "${cmdline}" \
                       --vmlinuz $BOOT_DIR_ABS/$KERNEL_ITB \
                       --arch arm > /dev/null
         for i in /dev/disk/by-id/*; do

--- a/scripts/96-chromebook.install
+++ b/scripts/96-chromebook.install
@@ -16,6 +16,7 @@ KERNEL_VBOOT="kernel.vboot"
 KERNEL_ITB="kernel.itb"
 # Compression method being used by coreboot
 compression="lz4"
+kernel="${KERNEL_IMAGE##*/}-${KERNEL_VERSION}"
 
 case "$COMMAND" in
     add)
@@ -24,9 +25,8 @@ case "$COMMAND" in
             exit 77;
         fi
 
-        kernel="${KERNEL_IMAGE##*/}-${KERNEL_VERSION}.${compression}"
-        rm -f "$BOOT_DIR_ABS/${KERNEL_IMAGE##*/}-${KERNEL_VERSION}.${compression}" || true
-        "${compression}" "$BOOT_DIR_ABS/${KERNEL_IMAGE##*/}-${KERNEL_VERSION}" "$BOOT_DIR_ABS/${KERNEL_IMAGE##*/}-${KERNEL_VERSION}.${compression}"
+        rm -f "$BOOT_DIR_ABS/${kernel}.${compression}" || true
+        "${compression}" "$BOOT_DIR_ABS/${kernel}" "$BOOT_DIR_ABS/${kernel}.${compression}"
 
         #Fedora kernel generates these device tree
         #FIXME: other existing dtb in /boot/dtb/* doesn't work with the FIT image
@@ -37,7 +37,7 @@ case "$COMMAND" in
 
         mkimage -D "-I dts -O dtb -p 2048" -i "$BOOT_DIR_ABS/$INITRD" \
                 -f auto -A arm64 -O linux -T kernel -C $compression -a 0 \
-                -d /boot/$kernel $dtbs \
+                -d /boot/"${kernel}.${compression}" $dtbs \
                 $BOOT_DIR_ABS/$KERNEL_ITB
 
         if [[ -f /etc/kernel/cmdline ]]; then

--- a/scripts/96-chromebook.install
+++ b/scripts/96-chromebook.install
@@ -14,6 +14,8 @@ fi
 
 KERNEL_VBOOT="kernel.vboot"
 KERNEL_ITB="kernel.itb"
+# Compression method being used by coreboot
+compression="lz4"
 
 case "$COMMAND" in
     add)
@@ -22,11 +24,9 @@ case "$COMMAND" in
             exit 77;
         fi
 
-        kernel="${KERNEL_IMAGE##*/}-${KERNEL_VERSION}.lz4"
-        # Compression method being used by coreboot
-        compression="lz4"
-        rm -f "$BOOT_DIR_ABS/${KERNEL_IMAGE##*/}-${KERNEL_VERSION}.lz4" || true
-        lz4 "$BOOT_DIR_ABS/${KERNEL_IMAGE##*/}-${KERNEL_VERSION}" "$BOOT_DIR_ABS/${KERNEL_IMAGE##*/}-${KERNEL_VERSION}.lz4"
+        kernel="${KERNEL_IMAGE##*/}-${KERNEL_VERSION}.${compression}"
+        rm -f "$BOOT_DIR_ABS/${KERNEL_IMAGE##*/}-${KERNEL_VERSION}.${compression}" || true
+        "${compression}" "$BOOT_DIR_ABS/${KERNEL_IMAGE##*/}-${KERNEL_VERSION}" "$BOOT_DIR_ABS/${KERNEL_IMAGE##*/}-${KERNEL_VERSION}.${compression}"
 
         #Fedora kernel generates these device tree
         #FIXME: other existing dtb in /boot/dtb/* doesn't work with the FIT image


### PR DESCRIPTION
This PR contains some fixes that were needed when testing the script to update a kernel package in a Fedora 36 installation.

It also contains some improvements and cleanups to make it more consistent with other kernel-install scripts, in preparation for the script to be shipped in a Fedora package.