### PR TITLE
chromebook.install: Make logic to choose kernel partition more robust

### DIFF
--- a/scripts/96-chromebook.install
+++ b/scripts/96-chromebook.install
@@ -67,9 +67,8 @@ case "$COMMAND" in
 
         # Store the FIT image in a partition of type kernel, that is present in
         # the storage device of the partition that is used to mount the rootfs.
-        major="$(mountpoint -d / | cut -d ':' -f1)"
-        sysfs="$(find /sys/dev -name ${major}:0)"
-        devnode="$(grep DEVNAME ${sysfs}/uevent | cut -d '=' -f2)"
+        rootdev="$(df -h | grep "/$" | cut -d ' ' -f1)"
+        devnode="$(lsblk -spnlo name "${rootdev}" | tail -n1)"
 
         partitions="$(cgpt find -t kernel)"
         for part in ${partitions}; do


### PR DESCRIPTION
The commit 2f18da84ba3e ("chromebook.install: Improve heuristic to choose writing partition") attempted to improve the logic used to pick the kernel partition, but it made some assumptions that were only true if partitions where in the first block device (e.g: /dev/sda).

But didn't take into account that the same block device major number would be used if there were more than one block device of the same type. Another case that would not work with the current heuristic is if a device mapper is used since in that case the kernel-install script should be able to get the actual mapped physical block device.

Rework the heuristic a little bit more again, to make it more general and less fragile. Instead of getting the block device major and minor for the root partition mountpoint, use the df command output to get the device.

Then use the lsblk command to determine the actual physical block device.

Fixes: 2f18da84ba3e ("chromebook.install: Improve heuristic to choose writing partition")
Reported-by: Enric Balletbo i Serra <eballetbo@redhat.com>
Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>