### PR TITLE
chromebook-setup: Download Fedora Rawhide images by default

### DIFF
--- a/chromebook-config.sh
+++ b/chromebook-config.sh
@@ -15,7 +15,7 @@ DEBIAN_SUITE="sid"
 ROOTFS_BASE_URL="https://people.collabora.com/~eballetbo/debian/images/"
 
 # Fedora rootfs images
-GETFEDORA="https://download.fedoraproject.org/pub/fedora/linux/releases/36/Workstation/aarch64/images/Fedora-Workstation-36-1.5.aarch64.raw.xz"
+GETFEDORA="https://download.fedoraproject.org/pub/fedora/linux/releases/36/Workstation/aarch64/images/"
 
 KERNEL_URL="git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git"
 

--- a/chromebook-config.sh
+++ b/chromebook-config.sh
@@ -15,7 +15,7 @@ DEBIAN_SUITE="sid"
 ROOTFS_BASE_URL="https://people.collabora.com/~eballetbo/debian/images/"
 
 # Fedora rootfs images
-GETFEDORA="https://download.fedoraproject.org/pub/fedora/linux/releases/36/Workstation/aarch64/images/"
+GETFEDORA="https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Workstation/aarch64/images/"
 
 KERNEL_URL="git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git"
 

--- a/chromebook-setup.sh
+++ b/chromebook-setup.sh
@@ -801,17 +801,16 @@ cmd_deploy_fedora()
         exit 1
     fi
     if [ -z "$IMAGE" ]; then
-        fedora_image=$(basename $GETFEDORA)
-        IMAGE=$(basename -s .xz $GETFEDORA)
-        if [ ! -f "$IMAGE" ]; then
-            echo "Downloading the default fedora image."
-            curl -OL $GETFEDORA
-            if [ -f "$fedora_image" ]; then
-                echo "Decompress .xz image"
-                sudo unxz "$fedora_image"
-            fi
+        fedora_image=$(curl -s -L $GETFEDORA | grep -o 'href=".*raw.xz">' | sed -e 's/href="//' -e 's/[>,", ].*//')
+        IMAGE=$(basename -s .xz $fedora_image)
+        if [ ! -f "$fedora_image" ] && [ ! -f "$IMAGE" ]; then
+            echo "Downloading image $fedora_image"
+            curl -OL $GETFEDORA/$fedora_image
         fi
-
+        if [ -f "$fedora_image" ]; then
+            echo "Decompress .xz image"
+            sudo unxz "$fedora_image"
+        fi
     fi
 
     CB_DISTRO=fedora

--- a/scripts/96-chromebook.install
+++ b/scripts/96-chromebook.install
@@ -67,9 +67,8 @@ case "$COMMAND" in
 
         # Store the FIT image in a partition of type kernel, that is present in
         # the storage device of the partition that is used to mount the rootfs.
-        major="$(mountpoint -d / | cut -d ':' -f1)"
-        sysfs="$(find /sys/dev -name ${major}:0)"
-        devnode="$(grep DEVNAME ${sysfs}/uevent | cut -d '=' -f2)"
+        rootdev="$(df -h | grep "/$" | cut -d ' ' -f1)"
+        devnode="$(lsblk -spnlo name "${rootdev}" | tail -n1)"
 
         partitions="$(cgpt find -t kernel)"
         for part in ${partitions}; do


### PR DESCRIPTION
This PR contains changes to determine the latest image and download from a URL and switch the default Fedora image to Rawhide.