### PR TITLE
Add an initramfs to the generated FIT image

### DIFF
--- a/chromebook-setup.sh
+++ b/chromebook-setup.sh
@@ -807,7 +807,7 @@ cmd_deploy_fedora()
             echo "Downloading image $fedora_image"
             curl -OL $GETFEDORA/$fedora_image
         fi
-        if [ -f "$fedora_image" ]; then
+        if [ ! -f "$IMAGE" ]; then
             echo "Decompress .xz image"
             sudo unxz "$fedora_image"
         fi

--- a/chromebook-setup.sh
+++ b/chromebook-setup.sh
@@ -665,7 +665,12 @@ cmd_build_vboot()
             ;;
     esac
 
-    echo "root=PARTUUID=%U/PARTNROFF=1 rootwait rw ${extra_kparams}" > boot_params
+    # Use the partition with label ROOT-A as the rootfs partition, since
+    # that is created by the script when the block device is partitioned.
+    #
+    # Also, there is a single rootfs partition in the used layout so the
+    # rootfs partition can be a fixed one.
+    echo "root=LABEL=ROOT-A rootwait rw ${extra_kparams}" > boot_params
     sudo vbutil_kernel --pack $CB_KERNEL_PATH/kernel.vboot \
                        --keyblock /usr/share/vboot/devkeys/kernel.keyblock \
                        --signprivate /usr/share/vboot/devkeys/kernel_data_key.vbprivk \


### PR DESCRIPTION
This PR contains some changes that allow to include an initramfs to the generated FIT image, which allows to have the needed drivers built as module instead of requiring them to be built-in the kernel image. 

That allows to use the Fedora kernel packages instead of a custom kernel build.