### PR TITLE
Install kernel and modules from the Fedora image

### DIFF
--- a/chromebook-setup.sh
+++ b/chromebook-setup.sh
@@ -799,9 +799,9 @@ cmd_setup_fedora_kernel()
         cat << EOF | sudo chroot /var$ROOTFS_DIR qemu-aarch64-static /bin/bash
         dracut --force -v --add-drivers "ulpi usb-storage phy-qcom-usb-hs-28nm \
         phy-qcom-usb-ss ocmem dwc3 dwc3-of-simple dwc3-pci ehci-platform xhci-plat-hcd \
-        i2c-qcom-geni i2c-qup icc-osm-l3 qcom-spmi-pmic phy-qcom-qmp phy-qcom-qusb2 \
+        i2c-qcom-geni i2c-qup icc-osm-l3 qcom-spmi-pmic phy-qcom-qmp-combo phy-qcom-qusb2 \
         phy-qcom-usb-hs qcom_aoss qcom-apcs-ipc-mailbox llcc-qcom nvmem_qfprom smem \
-        smp2p dwc3-qcom \
+        smp2p dwc3-qcom onboard_usb_hub \
         " /boot/initramfs-$kernel_version.img --kver $kernel_version --kmoddir /lib/modules/$kernel_version
         exit
 EOF


### PR DESCRIPTION
This pull-request contains the changes needed to use the kernel and modules from the Fedora image, instead of pulling them from a COPR. It also adds a required kernel module to prevent a USB regulator to be disabled:

`[   38.886278] pp3300_hub: disabling`