### PR TITLE
Make the kernel and root partition lookup more robust

### DIFF
--- a/chromebook-setup.sh
+++ b/chromebook-setup.sh
@@ -665,12 +665,16 @@ cmd_build_vboot()
             ;;
     esac
 
-    # Use the partition with label ROOT-A as the rootfs partition, since
-    # that is created by the script when the block device is partitioned.
-    #
-    # Also, there is a single rootfs partition in the used layout so the
-    # rootfs partition can be a fixed one.
-    echo "root=LABEL=ROOT-A rootwait rw ${extra_kparams}" > boot_params
+    # Use the root partition filesystem UUID if the partition is known,
+    # otherwise use as a fallback the ROOT-A label that is set when the
+    # root partition is formatted
+    if [ -n "$CB_SETUP_STORAGE2" ]; then
+        root_param="UUID=$(blkid ${CB_SETUP_STORAGE2} -s UUID -o value)"
+    else
+        root_param="LABEL=ROOT-A"
+    fi
+
+    echo "root=${root_param} rootwait rw ${extra_kparams}" > boot_params
     sudo vbutil_kernel --pack $CB_KERNEL_PATH/kernel.vboot \
                        --keyblock /usr/share/vboot/devkeys/kernel.keyblock \
                        --signprivate /usr/share/vboot/devkeys/kernel_data_key.vbprivk \

--- a/chromebook-setup.sh
+++ b/chromebook-setup.sh
@@ -772,15 +772,13 @@ cmd_setup_fedora_kernel()
         exit 1
     fi
 
-    rm -f vmlinuz-* initramfs-*
-
-    # Extract kernel and initramfs images
-    virt-builder --get-kernel "$IMAGE" -o .
-
-    local kernel_version="$(ls vmlinuz-* | sed -e 's/vmlinuz-//')"
-
     # Extract and copy the kernel packages to the rootfs
     mkdir ./tmpdir && cd ./tmpdir
+
+    # Extract kernel and initramfs images
+    virt-builder --get-kernel ../"$IMAGE" -o .
+
+    local kernel_version="$(ls vmlinuz-* | sed -e 's/vmlinuz-//')"
 
     # Generate modules.dep and map files, so modules autoload on first boot
     sudo depmod -b "$ROOTFS_DIR" $kernel_version

--- a/scripts/96-chromebook.install
+++ b/scripts/96-chromebook.install
@@ -70,11 +70,9 @@ case "$COMMAND" in
         rootdev="$(df -h | grep "/$" | cut -d ' ' -f1)"
         devnode="$(lsblk -spnlo name "${rootdev}" | tail -n1)"
 
-        partitions="$(cgpt find -t kernel)"
+        partitions="$(cgpt find -t kernel $devnode)"
         for part in ${partitions}; do
-            if [[ "${part##*/}" == "${devnode}"* ]]; then
-                dd if="${tmpdir}/${KERNEL_VBOOT}" of="${part}" bs=4M status=none
-            fi
+            dd if="${tmpdir}/${KERNEL_VBOOT}" of="${part}" bs=4M status=none
         done
         rm -rf "${tmpdir}"
         ;;


### PR DESCRIPTION
When querying the kernel partition to write the vboot image, only use the block device that contains the partition mounted as the root filesystem. This prevent to attempt using a kernel partition from a different OS install.

And use the root partition UUID as the `root=` param instead of just a `ROOT-A` label. Since there could be two OS using the same label, which would lead to the initramfs mounting the wrong root partition.