### PR TITLE
chromebook-setup: Fix two bugs in logic that generates the initrd

### DIFF
--- a/chromebook-setup.sh
+++ b/chromebook-setup.sh
@@ -239,10 +239,6 @@ shift
 # -----------------------------------------------------------------------------
 # Options sanitising
 
-if [ -z "$CB_KERNEL_PATH" ]; then
-    CB_KERNEL_PATH="kernel"
-fi
-
 [ -n "$CB_SETUP_STORAGE" ] || {
     echo "Incorrect path/storage device passed to the --storage option."
     print_usage_exit
@@ -538,6 +534,10 @@ cmd_get_kernel()
 {
     local arg_url
     local tag
+
+    if [ -z "$CB_KERNEL_PATH" ]; then
+        CB_KERNEL_PATH="kernel"
+    fi
 
     echo "Creating initial git repository if not already present..."
 


### PR DESCRIPTION
There were two bugs in the logic that extract the kernel version from the Fedora image and also generates an initrd using the modules in that image.

Because this should only be done if neither --kernel nor --initrd options are used. In the first case, no initrd has to be used unless is passed and in the second case, the specified initrd should be used, not generate one.

While being there, also fix the other issue that is wrong to assume that the image will always be in the tmpdir parent directory, since this a path to a different image can also be passed as an option.

Reported-by: Erico Nunes <ernunes@redhat.com>
Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>