### PR TITLE
chromebook-setup: Fix initrd reference in mkimage

### DIFF
--- a/chromebook-setup.sh
+++ b/chromebook-setup.sh
@@ -417,7 +417,7 @@ create_fit_image()
              initrd="-i arch/${ARCH}/boot/initramfs-$kernel_version.img"
          fi
          sudo mkimage -D "-I dts -O dtb -p 2048" -f auto -A ${ARCH} -O linux -T kernel -C $compression -a 0 \
-                 -d arch/${ARCH}/boot/$kernel ${initrd_option} $dtbs \
+                 -d arch/${ARCH}/boot/$kernel ${initrd} $dtbs \
                  kernel.itb
     else
 	echo "TODO: create x86_64 FIT image, now using a raw image"


### PR DESCRIPTION
Commit deb2d05 renamed the local variable "initrd_option" in create_fit_image() to "initrd". Replace also the reference to this variable in the mkimage call in the same function, as otherwise the image is always generated without an initrd.

Signed-off-by: Sergio Lopez <slp@redhat.com>