### PR TITLE
Add a newline after every > in curl HTML output

### DIFF
--- a/chromebook-setup.sh
+++ b/chromebook-setup.sh
@@ -833,7 +833,7 @@ cmd_deploy_fedora()
         exit 1
     fi
     if [ -z "$IMAGE" ]; then
-        fedora_image=$(curl -s -L $GETFEDORA | grep -o 'href=".*raw.xz">' | sed -e 's/href="//' -e 's/[>,", ].*//')
+        fedora_image=$(curl -s -L $GETFEDORA | sed "s/>/>\n/g" | grep -o 'href=".*raw.xz">' | sed -e 's/href="//' -e 's/[>,", ].*//')
         IMAGE=$(basename -s .xz $fedora_image)
         if [ ! -f "$fedora_image" ] && [ ! -f "$IMAGE" ]; then
             echo "Downloading image $fedora_image"


### PR DESCRIPTION
We probably need a smarter parser long-term, but in the case of Fedora 36, with the existing logic favicon.ico would be the result of this curl one-liner because of many href tags being on the same line. This fixes that by adding more new lines.

Tested urls (36 and rawhide):

"https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Workstation/aarch64/images/" "https://download.fedoraproject.org/pub/fedora/linux/releases/36/Workstation/aarch64/images/"