### PR TITLE
mkdir fails if directory already exists

### DIFF
--- a/chromebook-setup.sh
+++ b/chromebook-setup.sh
@@ -720,7 +720,7 @@ cmd_setup_fedora_rootfs()
     btrfs="${image/raw/btrfs}"
     dd if="${loopdev}p3" of="/var/tmp/$btrfs" conv=fsync status=progress
     losetup -D
-    mkdir ./tmpdir
+    rm -rf ./tmpdir && mkdir ./tmpdir
     mount "/var/tmp/$btrfs" ./tmpdir
     sleep 3
     echo "Disable SELINUX"


### PR DESCRIPTION
Sometimes mkdir fails, if tmpdir is already lying around from a previous
install, not sure what is best here "rm -rf tmpdir" or "mkdir -p",
starting from fresh is more deterministic I guess.
