### PR TITLE
chromebook.install: Fix kernel command line params read logic

### DIFF
--- a/scripts/96-chromebook.install
+++ b/scripts/96-chromebook.install
@@ -44,13 +44,11 @@ case "$COMMAND" in
                 "${tmpdir}/${KERNEL_ITB}" > /dev/null
 
         if [[ -f /etc/kernel/cmdline ]]; then
-            read -r -d '' -a BOOT_OPTIONS < /etc/kernel/cmdline
-
+            BOOT_OPTIONS="$(tr -s "$IFS" ' ' </etc/kernel/cmdline)"
         elif [[ -f /usr/lib/kernel/cmdline ]]; then
-            read -r -d '' -a BOOT_OPTIONS < /usr/lib/kernel/cmdline
+            BOOT_OPTIONS="$(tr -s "$IFS" ' ' </usr/lib/kernel/cmdline)"
         else
-            declare -a BOOT_OPTIONS
-            read -r -d '' BOOT_OPTIONS < /proc/cmdline
+            BOOT_OPTIONS="$(tr -s "$IFS" '\n' </proc/cmdline)"
         fi
 
         cmdline="${tmpdir}"/boot_params


### PR DESCRIPTION
The current logic uses `read -r -d ' ' -a` to read the cmdline, but this causes the read to stop after the first occurrence of the delimiter, i.e:

  $ read -r -d ' ' -a array <<< "foo bar"
  $ echo $array
  foo

This leads to only the 1st cmdline param to be included in the FIT image.

And even if read was executed without the -d ' ' delimiter option, it will only print the 1st element in the array. Instead, the array elements need to be expanded and stored as a string, i.e:

  $ read -r -a array <<< "foo bar"
  $ echo $array
  foo
  $ array="${array[@]}"
  $ echo $array
  foo bar

But let's just do the same than the 90-loaderentry.install script is doing that is using a `tr -s "$IFS" ' ' <` command instead, i.e:

  $ array="$(tr -s "$IFS" ' ' <<< "foo bar")"
  $ echo $array
  foo bar

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>