### PR TITLE
Allow to copy kernel modules from a Fedora image if are missing in the rootfs

### DIFF
--- a/chromebook-setup.sh
+++ b/chromebook-setup.sh
@@ -436,6 +436,11 @@ create_fit_image()
     fi
 }
 
+create_tmpdir()
+{
+    rm -rf ./tmpdir && mkdir ./tmpdir
+}
+
 # -----------------------------------------------------------------------------
 # Functions to run each command
 
@@ -705,7 +710,7 @@ cmd_setup_fedora_rootfs()
     dd if="${loopdev}p3" of="/var/tmp/$btrfs" conv=fsync status=progress
     losetup -d "$loopdev"
     umount ./tmpdir || true
-    rm -rf ./tmpdir && mkdir ./tmpdir
+    create_tmpdir
     mount "/var/tmp/$btrfs" ./tmpdir
     sleep 3
     echo "Disable SELINUX"
@@ -767,7 +772,7 @@ cmd_setup_fedora_kernel()
     image_path="$(readlink -f $IMAGE)"
 
     # Extract and copy the kernel packages to the rootfs
-    mkdir ./tmpdir && cd ./tmpdir
+    create_tmpdir && cd ./tmpdir
 
     # Extract kernel and initramfs images if were not provided
     if [ -z "$KERNEL" ] && [ -z "$INITRD" ]; then

--- a/chromebook-setup.sh
+++ b/chromebook-setup.sh
@@ -696,9 +696,7 @@ cmd_eject_storage()
     echo "All done."
 }
 
-# -----------------------------------------------------------------------------
-# Experimental: Create Fedora images for Chromebooks
-cmd_setup_fedora_rootfs()
+cmd_mount_fedora_rootfs()
 {
     local loopdev
     local image
@@ -709,10 +707,21 @@ cmd_setup_fedora_rootfs()
     btrfs="${image/raw/btrfs}"
     dd if="${loopdev}p3" of="/var/tmp/$btrfs" conv=fsync status=progress
     losetup -d "$loopdev"
-    umount ./tmpdir || true
     create_tmpdir
     mount "/var/tmp/$btrfs" ./tmpdir
     sleep 3
+}
+
+cmd_umount_fedora_rootfs()
+{
+    umount ./tmpdir
+    rm -rf ./tmpdir
+}
+
+# -----------------------------------------------------------------------------
+# Experimental: Create Fedora images for Chromebooks
+cmd_setup_fedora_rootfs()
+{
     echo "Disable SELINUX"
     sed -i 's/SELINUX=enforcing/SELINUX=permissive/' ./tmpdir/root/etc/selinux/config
 
@@ -735,8 +744,6 @@ cmd_setup_fedora_rootfs()
     # Copy the ROOTFS to media
     echo "copying ROOTFS to partition"
     cp -ar "./tmpdir/root/"* "$ROOTFS_DIR"
-    umount ./tmpdir
-    rm -rf ./tmpdir
 
     echo "Done."
 }
@@ -894,7 +901,9 @@ cmd_deploy_fedora()
     cmd_get_fedora_image
     cmd_format_storage
     cmd_mount_rootfs
+    cmd_mount_fedora_rootfs
     cmd_setup_fedora_rootfs
+    cmd_umount_fedora_rootfs
     cmd_setup_fedora_kernel
     cmd_eject_storage
 }

--- a/chromebook-setup.sh
+++ b/chromebook-setup.sh
@@ -779,7 +779,7 @@ cmd_setup_fedora_kernel()
     image_path="$(readlink -f $IMAGE)"
 
     # Extract and copy the kernel packages to the rootfs
-    create_tmpdir && cd ./tmpdir
+    create_tmpdir && pushd ./tmpdir
 
     # Extract kernel and initramfs images if were not provided
     if [ -z "$KERNEL" ] && [ -z "$INITRD" ]; then
@@ -791,6 +791,16 @@ cmd_setup_fedora_kernel()
     fi
 
     kernel_version="$(ls vmlinuz-* | sed -e 's/vmlinuz-//')"
+
+    popd && rm -rf ./tmpdir
+
+    if [ ! -d "$ROOTFS_DIR/lib/modules/$kernel_version" ]; then
+	cmd_mount_fedora_rootfs
+	cp -a ./tmpdir/root/lib/modules/$kernel_version "$ROOTFS_DIR/lib/modules/"
+	cmd_umount_fedora_rootfs
+    fi
+
+    create_tmpdir && pushd ./tmpdir
 
     # Generate modules.dep and map files, so modules autoload on first boot
     if [ -z "$ROOTFS_DIR" ]; then
@@ -843,7 +853,7 @@ EOF
     fi
     create_fit_image
 
-    cd - > /dev/null
+    popd
 
     export CB_KERNEL_PATH=./tmpdir
     cmd_build_vboot


### PR DESCRIPTION
This pull-request fixes an issue with the `chromebook-setup.sh` script. That is if the `deploy_fedora_kernel` command is used with a Fedora image that contains a kernel version different than installed in the `ROOT-A` partition, it will fail to generate the initramfs.

To prevent this, copy the modules from the Fedora image rootfs to the `ROOT-A` partition if these are not present already.