### PR TITLE
chromebook-setup: Add initial support for the Lenovo Duet 3

### DIFF
--- a/chromebook-setup.sh
+++ b/chromebook-setup.sh
@@ -391,6 +391,12 @@ create_fit_image()
             dtbs=" \
                 -b arch/arm64/boot/dts/qcom/sc7180-trogdor-coachz-r3.dtb \
                 -b arch/arm64/boot/dts/qcom/sc7180-trogdor-lazor-r3-kb.dtb \
+                -b arch/arm64/boot/dts/qcom/sc7180-trogdor-wormdingler-rev1-inx.dtb \
+                -b arch/arm64/boot/dts/qcom/sc7180-trogdor-wormdingler-rev1-boe-rt5682s.dtb \
+                -b arch/arm64/boot/dts/qcom/sc7180-trogdor-wormdingler-rev1-inx-rt5682s.dtb \
+                -b arch/arm64/boot/dts/qcom/sc7180-trogdor-wormdingler-rev0-boe.dtb \
+                -b arch/arm64/boot/dts/qcom/sc7180-trogdor-wormdingler-rev0-inx.dtb \
+                -b arch/arm64/boot/dts/qcom/sc7180-trogdor-wormdingler-rev1-boe.dtb \
                 -b arch/arm64/boot/dts/rockchip/rk3399-gru-kevin.dtb\
                 -b arch/arm64/boot/dts/rockchip/rk3399-gru-scarlet-inx.dtb \
                 "
@@ -398,6 +404,12 @@ create_fit_image()
             dtbs=" \
                 -b arch/arm64/boot/dts/qcom/sc7180-trogdor-coachz-r3.dtb \
                 -b arch/arm64/boot/dts/qcom/sc7180-trogdor-lazor-r3-kb.dtb \
+                -b arch/arm64/boot/dts/qcom/sc7180-trogdor-wormdingler-rev1-inx.dtb \
+                -b arch/arm64/boot/dts/qcom/sc7180-trogdor-wormdingler-rev1-boe-rt5682s.dtb \
+                -b arch/arm64/boot/dts/qcom/sc7180-trogdor-wormdingler-rev1-inx-rt5682s.dtb \
+                -b arch/arm64/boot/dts/qcom/sc7180-trogdor-wormdingler-rev0-boe.dtb \
+                -b arch/arm64/boot/dts/qcom/sc7180-trogdor-wormdingler-rev0-inx.dtb \
+                -b arch/arm64/boot/dts/qcom/sc7180-trogdor-wormdingler-rev1-boe.dtb \
                 -b arch/arm64/boot/dts/mediatek/mt8173-elm.dtb \
                 -b arch/arm64/boot/dts/mediatek/mt8173-elm-hana.dtb \
                 -b arch/arm64/boot/dts/mediatek/mt8183-kukui-krane-sku176.dtb \

--- a/scripts/96-chromebook.install
+++ b/scripts/96-chromebook.install
@@ -44,7 +44,13 @@ case "$COMMAND" in
         #FIXME: other existing dtb in /boot/dtb/* doesn't work with the FIT image
         dtbs="-b /boot/dtb-${KERNEL_VERSION}/qcom/sc7180-trogdor-coachz-r3.dtb \
               -b /boot/dtb-${KERNEL_VERSION}/qcom/sc7180-trogdor-lazor-r3-kb.dtb \
-              -b /boot/dtb-${KERNEL_VERSION}/rockchip/rk3399-gru-kevin.dtb\
+              -b /boot/dtb-${KERNEL_VERSION}/qcom/sc7180-trogdor-wormdingler-rev1-inx.dtb \
+              -b /boot/dtb-${KERNEL_VERSION}/qcom/sc7180-trogdor-wormdingler-rev1-boe-rt5682s.dtb \
+              -b /boot/dtb-${KERNEL_VERSION}/qcom/sc7180-trogdor-wormdingler-rev1-inx-rt5682s.dtb \
+              -b /boot/dtb-${KERNEL_VERSION}/qcom/sc7180-trogdor-wormdingler-rev0-boe.dtb \
+              -b /boot/dtb-${KERNEL_VERSION}/qcom/sc7180-trogdor-wormdingler-rev0-inx.dtb \
+              -b /boot/dtb-${KERNEL_VERSION}/qcom/sc7180-trogdor-wormdingler-rev1-boe.dtb \
+              -b /boot/dtb-${KERNEL_VERSION}/rockchip/rk3399-gru-kevin.dtb \
               -b /boot/dtb-${KERNEL_VERSION}/rockchip/rk3399-gru-scarlet-inx.dtb"
 
         mkimage -D "-I dts -O dtb -p 2048" -i "${BOOT_DIR_ABS}/${INITRD}" \


### PR DESCRIPTION
The Lenovo Duet 3 is a detachable device based on Qualcomm Snapdragon.