### PR TITLE
Make virt-builder invocation in chromebook-setup.sh more robust

### DIFF
--- a/chromebook-setup.sh
+++ b/chromebook-setup.sh
@@ -757,7 +757,7 @@ cmd_setup_fedora_kernel()
     # Extract kernel and initramfs images if were not provided
     if [ -z "$KERNEL" ] && [ -z "$INITRD" ]; then
         if [ -z "$COPR" ]; then
-            virt-builder --get-kernel "$image_path" -o .
+            LIBGUESTFS_BACKEND=direct virt-builder --get-kernel "$image_path" -o .
         else
              cmd_setup_copr_fedora_kernel
         fi


### PR DESCRIPTION
This is to prevent the following error:

  virt-get-kernel: error: libguestfs error: could not create appliance
  through libvirt.

  Try running qemu directly without libvirt using this environment variable:
  export LIBGUESTFS_BACKEND=direct

  Original error from libvirt: Cannot access backing file
  '/home/pdm/chromebooks/Fedora-Workstation-38-1.6.aarch64.raw' of storage
  file '/tmp/libguestfsej5kci/overlay1.qcow2' (as uid:107, gid:107):
  Permission denied [code=38 int1=13]