### PR TITLE
chromebook-setup: Look up partitions in /dev/disk/by-diskseq

### DIFF
--- a/chromebook-setup.sh
+++ b/chromebook-setup.sh
@@ -328,7 +328,7 @@ find_partitions_by_id()
 {
     unset CB_SETUP_STORAGE1 CB_SETUP_STORAGE2
 
-    for device in /dev/disk/by-id/*; do
+    for device in /dev/disk/by-diskseq/*; do
         if [ "$(realpath $device)" = $CB_SETUP_STORAGE ]; then
             if echo "$device" | grep -q -- "-part[0-9]*$"; then
                 echo "device $MMC must not be a partition part ($device)" 1>&2
@@ -353,7 +353,7 @@ find_partitions_by_id()
 
 wait_for_partitions_to_appear()
 {
-    for device in /dev/disk/by-id/*; do
+    for device in /dev/disk/by-diskseq/*; do
         if [ "$(realpath $device)" = $CB_SETUP_STORAGE ]; then
             if echo "$device" | grep -q -- "-part[0-9]*$"; then
                 echo "device $CB_SETUP_STORAGE must not be a partition part ($device)" 1>&2


### PR DESCRIPTION
Unlike /dev/disk/by-id, it works also for virtual hardware such as loop or zfs devices, which is great for testing without real hardware attached.

(Loop devices are actually not usable due to `losetup -D' in the code, but at least zfs volumes work.)