### PR TITLE
chromebook-setup: do not detach all devices

### DIFF
--- a/chromebook-setup.sh
+++ b/chromebook-setup.sh
@@ -703,7 +703,7 @@ cmd_setup_fedora_rootfs()
     loopdev="$(losetup --show -fP $IMAGE)"
     btrfs="${image/raw/btrfs}"
     dd if="${loopdev}p3" of="/var/tmp/$btrfs" conv=fsync status=progress
-    losetup -D
+    losetup -d "$loopdev"
     umount ./tmpdir || true
     rm -rf ./tmpdir && mkdir ./tmpdir
     mount "/var/tmp/$btrfs" ./tmpdir


### PR DESCRIPTION
`losetup -D` should never be called, instead we should just detach the loopback devices attached by this scriptspecifically.

Reported-by: Eric Curtin <ecurtin@redhat.com>