### PR TITLE
chromebook.install: Remove wormdingler-rev0 from the list of DTBs

### DIFF
--- a/scripts/96-chromebook.install
+++ b/scripts/96-chromebook.install
@@ -47,8 +47,6 @@ case "$COMMAND" in
               -b /boot/dtb-${KERNEL_VERSION}/qcom/sc7180-trogdor-wormdingler-rev1-inx.dtb \
               -b /boot/dtb-${KERNEL_VERSION}/qcom/sc7180-trogdor-wormdingler-rev1-boe-rt5682s.dtb \
               -b /boot/dtb-${KERNEL_VERSION}/qcom/sc7180-trogdor-wormdingler-rev1-inx-rt5682s.dtb \
-              -b /boot/dtb-${KERNEL_VERSION}/qcom/sc7180-trogdor-wormdingler-rev0-boe.dtb \
-              -b /boot/dtb-${KERNEL_VERSION}/qcom/sc7180-trogdor-wormdingler-rev0-inx.dtb \
               -b /boot/dtb-${KERNEL_VERSION}/qcom/sc7180-trogdor-wormdingler-rev1-boe.dtb \
               -b /boot/dtb-${KERNEL_VERSION}/rockchip/rk3399-gru-kevin.dtb \
               -b /boot/dtb-${KERNEL_VERSION}/rockchip/rk3399-gru-scarlet-inx.dtb"


### PR DESCRIPTION
The Linux kernel commit 62d882e62fe9 ("arm64: dts: qcom: sc7180: Delete wormdingler-rev0") that landed in Linux v6.4 removed the wormdingler rev0 DTBs. So let's removed from the list of DTB to include in the FIT as well.