### PR TITLE
image-installer: Add script for Fedora 39 Workstation

### DIFF
--- a/tools/image-installer/fedora-workstation-39-aarch64
+++ b/tools/image-installer/fedora-workstation-39-aarch64
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier:  GPL-2.0+
+# Automate Media Creation for Fedora Workstation 39 on ARM Chromebooks
+
+GETFEDORA="https://download.fedoraproject.org/pub/fedora/linux/releases/39/Workstation/aarch64/images/Fedora-Workstation-39-1.5.aarch64.raw.xz"
+IMAGE=$(basename -s .xz $GETFEDORA)
+MEDIA="$1"
+
+# usage message
+usage() {
+    echo "
+Usage: $(basename ${0}) <media device file (/dev/[sdX|mmcblkX])>
+"
+}
+
+if [ "$MEDIA" = "" ]; then
+    usage
+    exit 1
+fi
+
+if [ ! -f "$IMAGE" ]; then
+    if [ ! -f "$(basename $GETFEDORA)" ]; then
+        curl -OL "$GETFEDORA"
+    fi
+    unxz "$(basename $GETFEDORA)"
+fi
+
+sudo ./chromebook-setup.sh deploy_fedora --architecture=arm64 --storage="$1" --distro=fedora


### PR DESCRIPTION
This Fedora release should provide a much better out-of-the-box experience since not only the unzboot package is already included, but also the Linux kernel does not need command line parameters to workaround drivers bugs.