### PR TITLE
image-installer: Fix Fedora 39 script

### DIFF
--- a/tools/image-installer/fedora-workstation-39-aarch64
+++ b/tools/image-installer/fedora-workstation-39-aarch64
@@ -25,4 +25,4 @@ if [ ! -f "$IMAGE" ]; then
     unxz "$(basename $GETFEDORA)"
 fi
 
-sudo ./chromebook-setup.sh deploy_fedora --architecture=arm64 --storage="$1" --distro=fedora
+sudo ./chromebook-setup.sh deploy_fedora --architecture=arm64 --storage="$1" --distro=fedora --image="$IMAGE"


### PR DESCRIPTION
When dropping the --kparams option, also removed --image from the command.
Fix the script by adding this option again. Oops.

Reported-by: Kieran Bingham <kieran.bingham@ideasonboard.com>
Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>